### PR TITLE
feat(__init__): use Girder file API instead of zipping item files

### DIFF
--- a/girder_volview/web_client/package.json
+++ b/girder_volview/web_client/package.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "copy-webpack-plugin": "^4.5.2",
-        "volview-girder-client": "1.1.9"
+        "volview-girder-client": "1.1.10"
     },
     "peerDependencies": {
         "@girder/core": "*"

--- a/girder_volview/web_client/views/open.js
+++ b/girder_volview/web_client/views/open.js
@@ -13,13 +13,13 @@ function makeDownloadParams(model, itemRoute, files, config) {
     if (files.length === 0) return "";
 
     const hasSessionFiles = files.some(({ name }) => isSessionFile(name));
-    const downloadUrl = hasSessionFiles
-        ? `${itemRoute}/volview`
-        : `${itemRoute}/volview/datasets`;
+    const { url:downloadUrl, name } = hasSessionFiles
+        ? { url:`${itemRoute}/volview`, name: `${model.name()}.volview.zip` }
+        : { url:`${itemRoute}/volview/datasets`, name: `${model.name()}-files.json` }
 
     const configUrl = `${itemRoute}/volview/config/.volview_config.yaml`;
 
-    return `&names=[${model.name()}.zip,config.json]&urls=[${downloadUrl},${configUrl}]`;
+    return `&names=[${name},config.json]&urls=[${downloadUrl},${configUrl}]`;
 }
 
 export function open(model) {

--- a/volview-girder-client/buildvolview.sh
+++ b/volview-girder-client/buildvolview.sh
@@ -6,12 +6,12 @@ cd VolView
 # fetch just one commit
 git init
 git remote add origin https://github.com/Kitware/VolView.git
-git fetch origin 1c33fae4a7ac4861c716f755eece6b6fdd70520f --depth 1
+git fetch origin 7db5959dfda934b06182c74ef0c3a8552aa7f2f7 --depth 1
 git reset --hard FETCH_HEAD
 
 npm install
 npm run postinstall # avoid starting the build before patch-package done by running postinstall manualy 
- VITE_REMOTE_SERVER_URL= VITE_ENABLE_REMOTE_SAVE=true npm run build -- --base=/static/built/plugins/volview
+VITE_REMOTE_SERVER_URL= VITE_ENABLE_REMOTE_SAVE=true npm run build -- --base=/static/built/plugins/volview
 
 # remote so npm publish picks up VolView/dist
 rm .gitignore

--- a/volview-girder-client/package.json
+++ b/volview-girder-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "volview-girder-client",
-    "version": "1.1.9",
+    "version": "1.1.10",
     "description": "Built VolView with public path for DSA",
     "main": "index.js",
     "homepage": "https://github.com/girder/girder_volview",


### PR DESCRIPTION
Changes the `item/:id/volview/datasets` endpoint to return a VolView file manifest JSON.  Need to keep this `volview/datasets` endpoint so URLs within the session.volview.zip files can download the files in an item.  