### PR TITLE
File download endpoint with proxy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,10 @@ file download requests through the Girder server, rather than redirecting direct
 ```
 [volview]
 # Workaround CORS configuration errors in S3 assetstores.
-# If True, the Girder server will proxy file download requests from VolView
-# to the S3 assetstore. This will use more server bandwidth.
+# If True, the Girder server will proxy file download requests from 
+# VolView clients to the S3 assetstore. This will use more server bandwidth.
 # If False, VolView client requests to download files are redirected to S3.
+# Defaults to True.
 proxy_assetstores = True
 ```
 

--- a/girder_volview/__init__.py
+++ b/girder_volview/__init__.py
@@ -138,7 +138,7 @@ def downloadDatasets(self, item):
 @access.public(scope=TokenScope.DATA_READ, cookie=True)
 @boundHandler
 @autoDescribeRoute(
-    Description('Download a file.')
+    Description('Download a file with option to proxy.')
     .modelParam('id', model=FileModel, level=AccessType.READ)
     .param('name', 'The name of the file.  This is ignored.', paramType='path')
     .errorResponse('ID was invalid.')

--- a/girder_volview/web_client/package.json
+++ b/girder_volview/web_client/package.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "copy-webpack-plugin": "^4.5.2",
-        "volview-girder-client": "1.1.10"
+        "volview-girder-client": "1.2.0"
     },
     "peerDependencies": {
         "@girder/core": "*"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     keywords="girder-plugin, volview",
     name="girder_volview",
     packages=find_packages(exclude=["test", "test.*"]),
-    url="https://github.com/girder/girder_volview",
+    url="https://github.com/PaulHax/girder_volview",
     zip_safe=False,
     entry_points={"girder.plugin": ["volview = girder_volview:GirderPlugin"]},
     setup_requires=["setuptools_scm"],

--- a/volview-girder-client/buildvolview.sh
+++ b/volview-girder-client/buildvolview.sh
@@ -6,14 +6,14 @@ cd VolView
 # fetch just one commit
 git init
 git remote add origin https://github.com/Kitware/VolView.git
-git fetch origin 7db5959dfda934b06182c74ef0c3a8552aa7f2f7 --depth 1
+git fetch origin b1951c47250763068793e58e120bc3e6f23daadc --depth 1
 git reset --hard FETCH_HEAD
 
 npm install
 npm run postinstall # avoid starting the build before patch-package done by running postinstall manualy 
 VITE_REMOTE_SERVER_URL= VITE_ENABLE_REMOTE_SAVE=true npm run build -- --base=/static/built/plugins/volview
 
-# remote so npm publish picks up VolView/dist
+# remove so npm publish picks up VolView/dist
 rm .gitignore
 
 cd ..

--- a/volview-girder-client/package.json
+++ b/volview-girder-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "volview-girder-client",
-    "version": "1.1.10",
+    "version": "1.2.0",
     "description": "Built VolView with public path for DSA",
     "main": "index.js",
     "homepage": "https://github.com/girder/girder_volview",


### PR DESCRIPTION
New endpoint wraps `api/file/:id/download` with option to set `headers = False`.   When headers are false, Girder proxies the file from the assetstore.  Works around need for CORS configuration in S3 asset stores.

Adds a Girder setting check to turn proxing/headers on/off: `proxy_assetstores`
```
[volview]
# Workaround CORS configuration errors in S3 assetstores.
# If True, the Girder server will proxy file download requests from VolView
# to the S3 assetstore. This will use more server bandwidth.
# If False, VolView client requests to download files are redirected to S3.
# Defaults to True.
proxy_assetstores = True
```