### PR TITLE
Add "Open Checked/Folder" button to HierarchyWidget

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ proxy_assetstores = True
 
 ## API Endpoints
 
+- GET folder/:id/volview_manifest?items=[itemIds]&folders=[folderIds]
 - POST item/:id/volview -> upload file to Item with cookie authentication
 - GET item/:id/volview -> download latest session.volview.zip
 - GET item/:id/volview/manifest -> download JSON with URLs to all files in item except the `*.volview.zip`

--- a/README.md
+++ b/README.md
@@ -196,30 +196,6 @@ proxy_assetstores = True
 
 VolView creates a new session.volview.zip file in the Girder Item every time the Save button is clicked.
 
-## VolView Client Update Steps
-
-Change VolView commit SHA in `volview-girder-client/buildvolview.sh`
-
-Build VolView client with Girder specific CLI arguments:
-
-```sh
-cd volview-girder-client
-source buildvolview.sh
-```
-
-Increase version in `volview-girder-client/package.json`.
-
-Publish built VolView `dist` directory to NPM:
-
-```sh
-cd volview-girder-client
-npm publish
-```
-
-Update volview-girder-client version in `./grider_volview/web_client/package.json`
-
-To test new client: push up changes to a new branch on GitHub. Change `provision.divevolview.yaml` to point to your branch like this: `git+https://github.com/PaulHax/girder_volview@new-branch`.
-Rebuild DSA Girder docker image.
 
 ## Development
 
@@ -268,3 +244,28 @@ https://github.com/PaulHax/girder_volview/blob/main/volview-girder-client/buildv
 ```
 VITE_REMOTE_SERVER_URL= VITE_ENABLE_REMOTE_SAVE=true npm run build -- --base=/static/built/plugins/volview
 ```
+
+### VolView Client Update Steps
+
+Change VolView commit SHA in `volview-girder-client/buildvolview.sh`
+
+Build VolView client with Girder specific CLI arguments:
+
+```sh
+cd volview-girder-client
+source buildvolview.sh
+```
+
+Increase version in `volview-girder-client/package.json`.
+
+Publish built VolView `dist` directory to NPM:
+
+```sh
+cd volview-girder-client
+npm publish
+```
+
+Update volview-girder-client version in `./grider_volview/web_client/package.json`
+
+To test new client: push up changes to a new branch on GitHub. Change `provision.divevolview.yaml` to point to your branch like this: `git+https://github.com/PaulHax/girder_volview@new-branch`.
+Rebuild DSA Girder docker image.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ io:
   segmentGroupSaveFormat: "nrrd"
 ```
 
-## CORS Error Workaround by Proxying Assetstores 
+## CORS Error Workaround by Proxying Assetstores
 
 VolView will error if it loads a file from a S3 bucket asset store without some
 [CORS configuration](https://girder.readthedocs.io/en/stable/user-guide.html#s3).
@@ -168,7 +168,7 @@ file download requests through the Girder server, rather than redirecting direct
 ```
 [volview]
 # Workaround CORS configuration errors in S3 assetstores.
-# If True, the Girder server will proxy file download requests from 
+# If True, the Girder server will proxy file download requests from
 # VolView clients to the S3 assetstore. This will use more server bandwidth.
 # If False, VolView client requests to download files are redirected to S3.
 # Defaults to True.
@@ -177,11 +177,11 @@ proxy_assetstores = True
 
 ## API Endpoints
 
-- GET folder/:id/volview_manifest?items=[itemIds]&folders=[folderIds]
+- GET folder/:id/volview?items=[itemIds]&folders=[folderIds] -> download JSON with URLS to files or the latest `*.volview.zip` file in the folder
+- GET item/:id/volview -> download JSON with URLs to all files in item or the latest `*.volview.zip` file
 - POST item/:id/volview -> upload file to Item with cookie authentication
-- GET item/:id/volview -> download latest session.volview.zip
-- GET item/:id/volview/manifest -> download JSON with URLs to all files in item except the `*.volview.zip`
-- GET file/:id/proxiable/:name -> download a file with option to proxy 
+- GET file/:id/proxiable/:name -> download a file with option to proxy
+- GET folder/:id/volview_config/:name -> download JSON with VolView config properties
 - Deprecated: GET item/:id/volview/datasets -> download all files in item except the `*.volview.zip`
 
 ## Example Saving Roundtrip flow
@@ -239,35 +239,12 @@ services:
 
 Comment out the pip install of this plugin here: https://github.com/DigitalSlideArchive/digital_slide_archive/blob/master/devops/with-dive-volview/provision.divevolview.yaml#L3
 
-Then clean docker images
+To install volume mapped girder-volview plugin and incorporate changes as files are edited, add this to the `shell` section of the provision.yaml:
 
-```
-docker rm dsa-plus_girder_1 dsa-plus_worker_1 dsa-plus_rabbitmq_1 dsa-plus_memcached_1 dsa-plus_mongodb_1
-```
-
-Start containers again
-
-```
-DSA_USER=$(id -u):$(id -g) docker-compose -f ../dsa/docker-compose.yml -f docker-compose.override.yml -p dsa-plus up
-```
-
-Bash into girder container
-
-```
-DSA_USER=$(id -u):$(id -g) docker-compose -f ../dsa/docker-compose.yml -f docker-compose.override.yml -p dsa-plus exec girder bash
-```
-
-On Bash terminal, install your mounted local dev version of plugin.
-
-```
-cd /opt/girder_volview/ && pip install -e .
-```
-
-For the Girder plugin watch and rebuild feature, I must stop and start
-containers again. Then on Girder Bash prompt run
-
-```
-girder build --dev --watch-plugin volview
+```yaml
+shell:
+  - cd /opt/girder_volview/ && pip install -e .
+  - (sleep 30 && girder build --dev --watch-plugin volview)&
 ```
 
 ### Develop VolView client

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ proxy_assetstores = True
 
 ## Example Saving Roundtrip flow
 
+### Open Item
+
 1. User clicks Open in VolView for Item - Plugin checks if `*volview.zip` file exists in Item, finds none:
    Opens VolView with file download url `item/:id/volview/datasets`
 1. VolView opens, fetches from `item/:id/volview/datasets`, receives zip of all files in Item except files ending in `*volview.zip`
@@ -196,6 +198,14 @@ proxy_assetstores = True
 
 VolView creates a new session.volview.zip file in the Girder Item every time the Save button is clicked.
 
+### Open Checked
+
+1. User checks a set of items or folders. Clicks "Open Checked in VolView".
+1. Browser client updates the `lastOpened` metadata on a checked item/folder metadata with the current time.
+1. Browser opens VolView with file download url pointing to `GET folder/:id/volview?items=[...ids]&folders=[...ids]`. That endpoint returns a with URLs to Girder files.
+1. VolView save URL is pointing to `PUT folder/:id/volview?metadata={items: [...ids], folders: [...ids]}`. `metadata` parameter matches the checked set in the Girder file browser. User clicks save. `session.volview.zip` item is created in the folder with a `linkedResources` metadata key holding the folder and item IDs. If user checked a session.volview.zip item, then `items` points to an existing session.volview.zip. The new session.volview.zip takes the `linkedResources` of the older session.volview.zip.
+1. If user clicks refresh in VolView, the `GET folder/:id/volview?items=[]` end point is hit again. If a session.volview.zip is in the `items` parameter, the plugin reads the volview.zip's `linkedResources` and searches for a newer session.volview.zips with matching `linkedResources` and returns that if found.
+1. If user checks a new set of folders or items that does not include a session.volview.zip item, the `GET folder/:id/volview` endpoint does not pick a session.volview.zip with matching `linkedResources` as `lastOpened` metadata on one of the checked items/folders is newer than the matching session.volview.zip. This allows opening of images with a clean slate.
 
 ## Development
 

--- a/girder_volview/__init__.py
+++ b/girder_volview/__init__.py
@@ -1,6 +1,5 @@
 import cherrypy
 import errno
-from datetime import datetime
 
 from girder import plugin
 from girder.api.describe import Description, autoDescribeRoute
@@ -10,21 +9,17 @@ from girder.api.rest import (
     setResponseHeader,
     setContentDisposition,
 )
-from girder.utility.server import getApiRoot
 from girder.constants import AccessType, TokenScope, SortDir
 
-# saveSession
-from girder.models.file import File as FileModel
+from girder.models.file import File
 from girder.models.upload import Upload
-from girder.models.item import Item
 from girder.utility import RequestBodyStream
 from girder.exceptions import GirderException
 
-# downloadDatasets
-from girder.models.item import Item as ItemModel
+from girder.models.item import Item
 from girder.utility import ziputil
 
-# get config
+# used by get config
 import yaml
 from girder.models.setting import Setting
 from girder.models.folder import Folder
@@ -33,6 +28,22 @@ from girder.models.group import Group
 
 # server settings (from girder.cfg file probably) for proxiable endpoint below
 from girder.utility import config
+
+from .utils import (
+    isSessionItem,
+    isLoadableImage,
+    filesToManifest,
+    singleVolViewZipOrImageFiles,
+    idStringToIdList,
+    normalizeLinkedResources,
+    loadModels,
+    getFiles,
+    findNewestSession,
+    getLinkedResources,
+    matchesSelectionSet,
+    getNewestDoc,
+    getTouchedTime,
+)
 
 LARGE_IMAGE_CONFIG_FOLDER = "large_image.config_folder"
 
@@ -78,7 +89,7 @@ def uploadSession(model, parentId, user, size):
 
         return upload
     else:
-        return FileModel().filter(Upload().finalizeUpload(upload), user)
+        return File().filter(Upload().finalizeUpload(upload), user)
 
 
 @access.public(cookie=True, scope=TokenScope.DATA_WRITE)
@@ -95,7 +106,7 @@ def saveToItem(self, itemId):
             "Expected non-zero Content-Length header", "girder.api.v1.item.save-volview"
         )
 
-    return uploadSession(ItemModel, itemId, self.getCurrentUser(), size)
+    return uploadSession(Item, itemId, self.getCurrentUser(), size)
 
 
 @access.public(cookie=True, scope=TokenScope.DATA_WRITE)
@@ -124,40 +135,17 @@ def saveToFolder(self, folderId, metadata):
     # use its metadata.linkedResources as this item's metadata.linkedResources
     linkedResources = metadata["linkedResources"]
     linkedItems = normalizeLinkedResources(linkedResources)["items"]
-    selectedItems = loadItems(user, linkedItems)
+    selectedItems = loadModels(user, Item, linkedItems)
     newestSelectedSession = findNewestSession(selectedItems)
     if newestSelectedSession:
-        # Change selection set to match its linkedResources
-        # so we find most recent session that matches selection set
-        linkedResources = getLinkedResources(newestSelectedSession)
-        metadata = {"linkedResources": linkedResources}
+        # LinkedResources points to volview.zip.  Change saved volview.zip linkedResources
+        # to match selected linkedResources so we find most recent volview.zip next manifest
+        # request for those linkedResources.
+        metadata = {"linkedResources": getLinkedResources(newestSelectedSession)}
 
-    item = ItemModel().load(fileDic["itemId"], user=user)
-    ItemModel().setMetadata(item, metadata)
+    item = Item().load(fileDic["itemId"], user=user)
+    Item().setMetadata(item, metadata)
     return fileDic
-
-
-SESSION_ZIP_EXTENSION = ".volview.zip"
-
-
-def isSessionItem(item):
-    if SESSION_ZIP_EXTENSION in item["name"]:
-        return True
-    return False
-
-
-def isSessionFile(path):
-    if path.endswith(SESSION_ZIP_EXTENSION):
-        return True
-    return False
-
-
-def isLoadableData(path):
-    if isSessionFile(path):
-        return False
-    if path.endswith("volview_config.yaml"):
-        return False
-    return True
 
 
 # Deprecated, use downloadManifest
@@ -165,7 +153,7 @@ def isLoadableData(path):
 @boundHandler
 @autoDescribeRoute(
     Description("Download zip of item files that do not end in volview.zip")
-    .modelParam("itemId", model=ItemModel, level=AccessType.READ)
+    .modelParam("itemId", model=Item, level=AccessType.READ)
     .produces(["application/zip"])
     .errorResponse("ID was invalid.")
     .errorResponse("Read access was denied for the item.", 403)
@@ -178,8 +166,8 @@ def downloadDatasets(self, item):
         zip = ziputil.ZipGenerator(item["name"])
         sansSessions = [
             fileEntry
-            for fileEntry in ItemModel().fileList(item, subpath=False)
-            if isLoadableData(fileEntry[0])
+            for fileEntry in Item().fileList(item, subpath=False)
+            if isLoadableImage(fileEntry[0])
         ]
         for path, file in sansSessions:
             for data in zip.addFile(file, path):
@@ -193,76 +181,14 @@ def downloadDatasets(self, item):
 @boundHandler
 @autoDescribeRoute(
     Description("Download a file with option to proxy.")
-    .modelParam("id", model=FileModel, level=AccessType.READ)
+    .modelParam("id", model=File, level=AccessType.READ)
     .param("name", "The name of the file.  This is ignored.", paramType="path")
     .errorResponse("ID was invalid.")
     .errorResponse("Read access was denied on the parent folder.", 403)
 )
 def downloadProxiableFile(self, file, name):
     proxyRequest = config.getConfig().get("volview", {}).get("proxy_assetstores", True)
-    return FileModel().download(file, headers=not proxyRequest)
-
-
-def makeFileDownloadUrl(fileModel):
-    """
-    Given a file model, return a download URL for the file.
-    :param fileModel: the file model.
-    :type fileModel: dict
-    :returns: the download URL.
-    """
-    # Lead with a slash to make the URI relative to origin
-    fileUrl = "/".join(
-        (
-            "",
-            getApiRoot(),
-            "file",
-            str(fileModel["_id"]),
-            "proxiable",
-            fileModel["name"],
-        )
-    )
-    return fileUrl
-
-
-def filesToManifest(files, folderId):
-    fileUrls = [
-        {"url": makeFileDownloadUrl(fileEntry[1]), "name": fileEntry[1]["name"]}
-        for fileEntry in files
-    ]
-    configUrl = "/".join(
-        (
-            "",
-            getApiRoot(),
-            "folder",
-            str(folderId),
-            "volview_config",
-            ".volview_config.yaml",
-        )
-    )
-    fileUrls.append({"url": configUrl, "name": "config.json"})
-    fileManifest = {"resources": fileUrls}
-    return fileManifest
-
-
-def sameLevelSessionFile(fileEntry):
-    # if file name matches the item name, then Item.fileList has no / in the path
-    # example: itemName == session.volview.zip and fileName == session.volview.zip, then path == session.volview.zip
-    # example: itemName == "session.volview.zip (1)" and fileName == session.volview.zip, then path == session.volview.zip (1)/session.volview.zip
-    paths = fileEntry[0].split("/")
-    rootPath = paths[0]
-    itemNameIncludesSessionZip = rootPath.find(SESSION_ZIP_EXTENSION) != -1
-    directChildSessionZip = len(paths) <= 2 and itemNameIncludesSessionZip
-    return directChildSessionZip and isSessionFile(fileEntry[0])
-
-
-def singleVolViewZipOrImageFiles(files):
-    sessions = [fileEntry for fileEntry in files if sameLevelSessionFile(fileEntry)]
-    if sessions:
-        # load latest session
-        newestSession = max(sessions, key=lambda file: file[1].get("created"))
-        return [newestSession]
-    else:
-        return [file for file in files if isLoadableData(file[0])]
+    return File().download(file, headers=not proxyRequest)
 
 
 @access.public(cookie=True, scope=TokenScope.DATA_READ)
@@ -271,81 +197,15 @@ def singleVolViewZipOrImageFiles(files):
     Description(
         "Download JSON listing item file download URIs that do not end in volview.zip"
     )
-    .modelParam("itemId", model=ItemModel, level=AccessType.READ)
+    .modelParam("itemId", model=Item, level=AccessType.READ)
     .produces(["application/json"])
     .errorResponse("ID was invalid.")
     .errorResponse("Read access was denied for the item.", 403)
 )
 def downloadManifest(self, item):
-    allFiles = list(ItemModel().fileList(item, subpath=False, data=False))
+    allFiles = list(Item().fileList(item, subpath=False, data=False))
     files = singleVolViewZipOrImageFiles(allFiles)
     return filesToManifest(files, item["folderId"])
-
-
-def getFileList(model, id, user):
-    doc = model().load(id, user=user, exc=True)
-    return model().fileList(doc, subpath=False, data=False)
-
-
-def idStringToIdList(idString):
-    if len(idString) == 0:
-        return []
-    return idString.split(",")
-
-
-def getFiles(model, idList, user):
-    fileLists = [getFileList(model, id, user) for id in idList]
-    # flatten
-    files = [file for fileList in fileLists for file in fileList]
-    return files
-
-
-def loadItems(user, itemIds):
-    return [ItemModel().load(itemId, user=user) for itemId in itemIds]
-
-
-def normalizeLinkedResources(linkedResources):
-    if not linkedResources:
-        return {"folders": [], "items": []}
-    folders = linkedResources.get("folders", [])
-    items = linkedResources.get("items", [])
-    return {"folders": folders, "items": items}
-
-
-def getLinkedResources(item):
-    linkedResources = item.get("meta", {}).get("linkedResources")
-    return normalizeLinkedResources(linkedResources)
-
-
-def matchesSelectionSet(folders, items, sessionItem):
-    linkedResources = getLinkedResources(sessionItem)
-    if not linkedResources:
-        return False
-    for folder in folders:
-        if not folder in linkedResources.get("folders", []):
-            return False
-    for item in items:
-        if not item in linkedResources.get("items", []):
-            return False
-    return True
-
-
-def getTouchedTime(item):
-    if item.get("meta").get("lastOpened"):
-        dateString = item.get("meta").get("lastOpened")
-        return datetime.strptime(dateString, "%Y-%m-%dT%H:%M:%S.%fZ")
-    return item.get("updated") or item.get("created")
-
-
-def getNewestSession(sessions):
-    return max(sessions, key=lambda session: getTouchedTime(session))
-
-
-def findNewestSession(items):
-    selectedSessions = [item for item in items if isSessionItem(item)]
-    if selectedSessions:
-        return getNewestSession(selectedSessions)
-    return []
 
 
 @access.public(cookie=True, scope=TokenScope.DATA_READ)
@@ -372,8 +232,8 @@ def downloadResourceManifest(self, folder, folders, items):
         ]
         files = singleVolViewZipOrImageFiles(filesInFolder)
     else:
-        # Load selected files.
-        selectedItems = loadItems(user, items)
+        # else load selected files
+        selectedItems = loadModels(user, Item, items)
         # If any selected items are session.volview.zip,
         # find freshest and change selection set to match its linkedResources.
         newestSelectedSession = findNewestSession(selectedItems)
@@ -391,20 +251,21 @@ def downloadResourceManifest(self, folder, folders, items):
             for session in sessionItems
             if matchesSelectionSet(folders, items, session)
         ]
-        if matchingSessionItems:
-            latestSession = getNewestSession(matchingSessionItems)
+        latestSession = getNewestDoc(matchingSessionItems)
+        # compare touched time of session with max touched time of selected items/folders
+        selectedFolders = loadModels(user, Folder, folders)
+        latestSelectedDoc = getNewestDoc(selectedFolders + selectedItems)
+        if latestSession and getTouchedTime(latestSession) >= getTouchedTime(
+            latestSelectedDoc
+        ):
+            # session touched time is newer than selected items/folders so load it
             files = singleVolViewZipOrImageFiles(
                 Item().fileList(latestSession, subpath=False, data=False)
             )
         else:
             # Load selected folders and items excluding child session.volview.zip and .volview_config.yaml
-            itemFiles = [
-                Item().fileList(item, subpath=False, data=False)
-                for item in selectedItems
-            ]
-            itemFiles = [file for fileList in itemFiles for file in fileList]
-            files = getFiles(Folder, folders, user) + itemFiles
-            files = [file for file in files if isLoadableData(file[0])]
+            files = getFiles(Folder, selectedFolders) + getFiles(Item, selectedItems)
+            files = [file for file in files if isLoadableImage(file[0])]
     return filesToManifest(files, folder["_id"])
 
 
@@ -480,7 +341,7 @@ def yamlConfigFile(folder, name, user, addConfig):
                 if file["size"] > 10 * 1024**2:
                     logger.info("Not loading %s -- too large" % file["name"])
                     continue
-                with FileModel().open(file) as fptr:
+                with File().open(file) as fptr:
                     config = yaml.safe_load(fptr)
                     if isinstance(config, list) and len(config) == 1:
                         config = config[0]

--- a/girder_volview/__init__.py
+++ b/girder_volview/__init__.py
@@ -143,7 +143,7 @@ def saveToFolder(self, folderId, metadata):
         # request for those linkedResources.
         metadata = {"linkedResources": getLinkedResources(newestSelectedSession)}
 
-    item = Item().load(fileDic["itemId"], user=user)
+    item = Item().load(fileDic["itemId"], user=user, level=AccessType.WRITE, exc=True)
     Item().setMetadata(item, metadata)
     return fileDic
 
@@ -255,8 +255,10 @@ def downloadResourceManifest(self, folder, folders, items):
         # compare touched time of session with max touched time of selected items/folders
         selectedFolders = loadModels(user, Folder, folders)
         latestSelectedDoc = getNewestDoc(selectedFolders + selectedItems)
-        if latestSession and getTouchedTime(latestSession) >= getTouchedTime(
-            latestSelectedDoc
+        if (
+            latestSession
+            and latestSelectedDoc
+            and getTouchedTime(latestSession) >= getTouchedTime(latestSelectedDoc)
         ):
             # session touched time is newer than selected items/folders so load it
             files = singleVolViewZipOrImageFiles(

--- a/girder_volview/__init__.py
+++ b/girder_volview/__init__.py
@@ -195,6 +195,26 @@ def makeFileDownloadUrl(fileModel):
     return fileUrl
 
 
+def filesToManifest(files, folderId):
+    fileUrls = [
+        {"url": makeFileDownloadUrl(fileEntry[1]), "name": fileEntry[1]["name"]}
+        for fileEntry in files
+    ]
+    configUrl = "/".join(
+        (
+            "",
+            getApiRoot(),
+            "folder",
+            str(folderId),
+            "volview_config",
+            ".volview_config.yaml",
+        )
+    )
+    fileUrls.append({"url": configUrl, "name": "config.json"})
+    fileManifest = {"resources": fileUrls}
+    return fileManifest
+
+
 @access.public(cookie=True, scope=TokenScope.DATA_READ)
 @boundHandler
 @autoDescribeRoute(
@@ -212,12 +232,7 @@ def downloadManifest(self, item):
         for fileEntry in ItemModel().fileList(item, subpath=False, data=False)
         if isLoadableData(fileEntry[0])
     ]
-    fileUrls = [
-        {"url": makeFileDownloadUrl(fileEntry[1]), "name": fileEntry[1]["name"]}
-        for fileEntry in filesNoVolViewZips
-    ]
-    fileManifest = {"resources": fileUrls}
-    return fileManifest
+    return filesToManifest(filesNoVolViewZips, item["folderId"])
 
 
 def getFileList(model, id):
@@ -287,24 +302,7 @@ def downloadResourceManifest(self, folder, folders, items):
         else:
             files = getFiles(Folder, folders) + itemFiles
             files = [file for file in files if isLoadableData(file[0])]
-
-    fileUrls = [
-        {"url": makeFileDownloadUrl(fileEntry[1]), "name": fileEntry[1]["name"]}
-        for fileEntry in files
-    ]
-    configUrl = "/".join(
-        (
-            "",
-            getApiRoot(),
-            "folder",
-            str(folder["_id"]),
-            "volview_config",
-            ".volview_config.yaml",
-        )
-    )
-    fileUrls.append({"url": configUrl, "name": "config.json"})
-    fileManifest = {"resources": fileUrls}
-    return fileManifest
+    return filesToManifest(files, folder["_id"])
 
 
 @access.public(cookie=True, scope=TokenScope.DATA_READ)
@@ -473,40 +471,6 @@ def yamlConfigFile(folder, name, user, addConfig):
         "present and if the user is an admin, respectively (both get merged "
         "for admins)."
     )
-    .modelParam("itemId", model=ItemModel, level=AccessType.READ)
-    .param("name", "The name of the file.", paramType="path")
-    .produces(["application/json"])
-    .errorResponse()
-)
-def getConfigFile(self, item, name):
-    folderId = item["folderId"]
-    user = self.getCurrentUser()
-    folder = Folder().load(folderId, user=user, level=AccessType.READ)
-    baseConfig = {"dataBrowser": {"hideSampleData": True}}
-    config = yamlConfigFile(folder, name, user, baseConfig)
-    return config
-
-
-@access.public(cookie=True, scope=TokenScope.DATA_READ)
-@boundHandler()
-@autoDescribeRoute(
-    Description("Get a VolView config file.")
-    .notes(
-        "Wraps large image yaml_config endpoint and inserts more properties. "
-        "This walks up the chain of parent folders until the file is found.  "
-        "If not found, the .config folder in the parent collection or user is "
-        "checked.\n\nAny yaml file can be returned.  If the top-level is a "
-        'dictionary and contains keys "access" or "groups" where those are '
-        "dictionaries, the returned value will be modified based on the "
-        'current user.  The "groups" dictionary contains keys that are group '
-        "names and values that update the main dictionary.  All groups that "
-        "the user is a member of are merged in alphabetical order.  If a key "
-        'and value of "\\__all\\__": True exists, the replacement is total; '
-        'otherwise it is a merge.  If the "access" dictionary exists, the '
-        '"user" and "admin" subdictionaries are merged if a calling user is '
-        "present and if the user is an admin, respectively (both get merged "
-        "for admins)."
-    )
     .modelParam("folderId", model=Folder, level=AccessType.READ)
     .param("name", "The name of the file.", paramType="path")
     .produces(["application/json"])
@@ -535,9 +499,6 @@ class GirderPlugin(plugin.GirderPlugin):
         )
         info["apiRoot"].item.route(
             "GET", (":itemId", "volview", "manifest"), downloadManifest
-        )
-        info["apiRoot"].item.route(
-            "GET", (":itemId", "volview", "config", ":name"), getConfigFile
         )
         info["apiRoot"].folder.route(
             "GET", (":folderId", "volview_manifest"), downloadResourceManifest

--- a/girder_volview/utils.py
+++ b/girder_volview/utils.py
@@ -1,0 +1,144 @@
+from datetime import datetime
+from girder.utility.server import getApiRoot
+from girder.models.item import Item
+
+SESSION_ZIP_EXTENSION = ".volview.zip"
+
+
+def isSessionItem(item):
+    if SESSION_ZIP_EXTENSION in item["name"]:
+        return True
+    return False
+
+
+def isSessionFile(path):
+    if path.endswith(SESSION_ZIP_EXTENSION):
+        return True
+    return False
+
+
+def isLoadableImage(path):
+    if isSessionFile(path):
+        return False
+    if path.endswith("volview_config.yaml"):
+        return False
+    return True
+
+
+def makeFileDownloadUrl(fileModel):
+    """
+    Given a file model, return a download URL for the file.
+    :param fileModel: the file model.
+    :type fileModel: dict
+    :returns: the download URL.
+    """
+    # Lead with a slash to make the URI relative to origin
+    fileUrl = "/".join(
+        (
+            "",
+            getApiRoot(),
+            "file",
+            str(fileModel["_id"]),
+            "proxiable",
+            fileModel["name"],
+        )
+    )
+    return fileUrl
+
+
+def filesToManifest(files, folderId):
+    fileUrls = [
+        {"url": makeFileDownloadUrl(fileEntry[1]), "name": fileEntry[1]["name"]}
+        for fileEntry in files
+    ]
+    configUrl = "/".join(
+        (
+            "",
+            getApiRoot(),
+            "folder",
+            str(folderId),
+            "volview_config",
+            ".volview_config.yaml",
+        )
+    )
+    fileUrls.append({"url": configUrl, "name": "config.json"})
+    fileManifest = {"resources": fileUrls}
+    return fileManifest
+
+
+def sameLevelSessionFile(fileEntry):
+    # if file name matches the item name, then Item.fileList has no / in the path
+    # example: itemName == session.volview.zip and fileName == session.volview.zip, then path == session.volview.zip
+    # example: itemName == "session.volview.zip (1)" and fileName == session.volview.zip, then path == session.volview.zip (1)/session.volview.zip
+    paths = fileEntry[0].split("/")
+    rootPath = paths[0]
+    itemNameIncludesSessionZip = rootPath.find(SESSION_ZIP_EXTENSION) != -1
+    directChildSessionZip = len(paths) <= 2 and itemNameIncludesSessionZip
+    return directChildSessionZip and isSessionFile(fileEntry[0])
+
+
+def singleVolViewZipOrImageFiles(files):
+    sessions = [fileEntry for fileEntry in files if sameLevelSessionFile(fileEntry)]
+    if sessions:
+        # load latest session
+        newestSession = max(sessions, key=lambda file: file[1].get("created"))
+        return [newestSession]
+    else:
+        return [file for file in files if isLoadableImage(file[0])]
+
+
+def idStringToIdList(idString):
+    if len(idString) == 0:
+        return []
+    return idString.split(",")
+
+
+def getFiles(model, docs):
+    fileLists = [model().fileList(doc, subpath=False, data=False) for doc in docs]
+    # flatten
+    files = [file for fileList in fileLists for file in fileList]
+    return files
+
+
+def loadModels(user, model, docIds):
+    return [model().load(id, user=user) for id in docIds]
+
+
+def normalizeLinkedResources(linkedResources):
+    if not linkedResources:
+        return {"folders": [], "items": []}
+    folders = linkedResources.get("folders", [])
+    items = linkedResources.get("items", [])
+    return {"folders": folders, "items": items}
+
+
+def getLinkedResources(item):
+    resources = item.get("meta", {}).get("linkedResources", {})
+    return normalizeLinkedResources(resources)
+
+
+def matchesSelectionSet(folders, items, item):
+    foldersA = set(folders or [])
+    itemsA = set(items or [])
+    itemResources = getLinkedResources(item)
+    foldersB = set(itemResources.get("folders", []))
+    itemsB = set(itemResources.get("items", []))
+    return foldersA == foldersB and itemsA == itemsB
+
+
+def getTouchedTime(item):
+    if item.get("meta").get("lastOpened"):
+        dateString = item.get("meta").get("lastOpened")
+        return datetime.strptime(dateString, "%Y-%m-%dT%H:%M:%S.%fZ")
+    return item.get("updated") or item.get("created")
+
+
+def getNewestDoc(docs):
+    if not docs:
+        return None
+    return max(docs, key=lambda session: getTouchedTime(session))
+
+
+def findNewestSession(items):
+    sessions = [item for item in items if isSessionItem(item)]
+    return getNewestDoc(sessions)

--- a/girder_volview/utils.py
+++ b/girder_volview/utils.py
@@ -1,12 +1,12 @@
 from datetime import datetime
 from girder.utility.server import getApiRoot
-from girder.models.item import Item
+from girder.constants import AccessType
 
 SESSION_ZIP_EXTENSION = ".volview.zip"
 
 
 def isSessionItem(item):
-    if SESSION_ZIP_EXTENSION in item["name"]:
+    if item and SESSION_ZIP_EXTENSION in item["name"]:
         return True
     return False
 
@@ -100,8 +100,8 @@ def getFiles(model, docs):
     return files
 
 
-def loadModels(user, model, docIds):
-    return [model().load(id, user=user) for id in docIds]
+def loadModels(user, model, docIds, level=AccessType.READ):
+    return [model().load(id, level=level, user=user) for id in docIds]
 
 
 def normalizeLinkedResources(linkedResources):
@@ -134,9 +134,11 @@ def getTouchedTime(item):
 
 
 def getNewestDoc(docs):
-    if not docs:
+    # filter out IDs that don't exist
+    loadedDocs = [doc for doc in docs if doc]
+    if not loadedDocs:
         return None
-    return max(docs, key=lambda session: getTouchedTime(session))
+    return max(loadedDocs, key=lambda session: getTouchedTime(session))
 
 
 def findNewestSession(items):

--- a/girder_volview/web_client/main.js
+++ b/girder_volview/web_client/main.js
@@ -1,2 +1,3 @@
 // import modules for side effects
 import "./views/itemPage";
+import "./views/HierarchyWidget";

--- a/girder_volview/web_client/package.json
+++ b/girder_volview/web_client/package.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "copy-webpack-plugin": "^4.5.2",
-        "volview-girder-client": "1.2.0"
+        "volview-girder-client": "1.2.1"
     },
     "peerDependencies": {
         "@girder/core": "*"

--- a/girder_volview/web_client/views/HierarchyWidget.js
+++ b/girder_volview/web_client/views/HierarchyWidget.js
@@ -1,0 +1,34 @@
+import HierarchyWidget from "@girder/core/views/widgets/HierarchyWidget";
+import { wrap } from "@girder/core/utilities/PluginUtils";
+import { openButton, openFiles } from "./open";
+import { restRequest } from "@girder/core/rest";
+
+wrap(HierarchyWidget, "render", function (render) {
+    render.call(this);
+
+    this.$(".g-folder-header-buttons .g-folder-info-button").before(openButton);
+    const buttons = this.$el.find(".open-in-volview");
+
+    buttons[0].onclick = () => {
+        const resources = JSON.parse(this._getCheckedResourceParam());
+        const items = resources.item.map((cid) =>
+            this.itemListView.collection.get(cid)
+        );
+        Promise.all(
+            items.map((item) => {
+                return new Promise((resolve) => {
+                    restRequest({
+                        type: "GET",
+                        url: `item/${item.id}/files?limit=0`,
+                        error: null,
+                    }).done((files) => {
+                        resolve(files);
+                    });
+                });
+            })
+        ).then((files) => {
+            const allFiles = files.flat();
+            openFiles(this.parentModel, allFiles);
+        });
+    };
+});

--- a/girder_volview/web_client/views/HierarchyWidget.js
+++ b/girder_volview/web_client/views/HierarchyWidget.js
@@ -1,9 +1,25 @@
 import HierarchyWidget from "@girder/core/views/widgets/HierarchyWidget";
+import { restRequest } from "@girder/core/rest";
+import { confirm } from "@girder/core/dialog";
 import { wrap } from "@girder/core/utilities/PluginUtils";
 import { openButton, openResources } from "./open";
 
 const openFolder = '<i class="icon-link-ext"></i>Open Folder in VolView</a>';
 const openChecked = '<i class="icon-link-ext"></i>Open Checked in VolView</a>';
+
+function loadVolViewZip(volViewZip, resources, parentModel) {
+    // found a VolView zip, update lastOpened so manifest endpoint opens it
+    restRequest({
+        type: "GET",
+        url: `item/${volViewZip.id}/metadata`,
+        contentType: "application/json",
+        data: JSON.stringify({ lastOpened: new Date() }),
+        method: "PUT",
+        error: null,
+    }).done(() => {
+        openResources(parentModel, resources);
+    });
+}
 
 wrap(HierarchyWidget, "render", function (render) {
     render.call(this);
@@ -18,6 +34,41 @@ wrap(HierarchyWidget, "render", function (render) {
 
     button.onclick = () => {
         const resources = JSON.parse(this._getCheckedResourceParam());
+
+        if (resources.item && resources.item.length > 0) {
+            const items = resources.item.map((cid) =>
+                this.itemListView.collection.get(cid)
+            );
+            const volViewZipsNewestFirst = items
+                .filter((item) => item.attributes.name.includes(".volview.zip"))
+                .sort(
+                    (a, b) =>
+                        new Date(b.attributes.created) -
+                        new Date(a.attributes.created)
+                );
+
+            if (volViewZipsNewestFirst.length > 0) {
+                const volViewZip = volViewZipsNewestFirst[0];
+                // Only newest checked volview.zip item will be opened
+                if (items.length >= 2) {
+                    confirm({
+                        text: `Will open newest VolView zip file: ${volViewZip.attributes.name}.`,
+                        yesText: "Open",
+                        confirmCallback: () => {
+                            loadVolViewZip(
+                                volViewZip,
+                                resources,
+                                this.parentModel
+                            );
+                        },
+                    });
+                    return;
+                } else {
+                    loadVolViewZip(volViewZip, resources, this.parentModel);
+                    return;
+                }
+            }
+        }
         openResources(this.parentModel, resources);
     };
 

--- a/girder_volview/web_client/views/HierarchyWidget.js
+++ b/girder_volview/web_client/views/HierarchyWidget.js
@@ -1,16 +1,28 @@
 import HierarchyWidget from "@girder/core/views/widgets/HierarchyWidget";
 import { wrap } from "@girder/core/utilities/PluginUtils";
 import { openButton, openResources } from "./open";
-import { restRequest } from "@girder/core/rest";
+
+const openFolder = '<i class="icon-link-ext"></i>Open Folder in VolView</a>';
+const openChecked = '<i class="icon-link-ext"></i>Open Checked in VolView</a>';
 
 wrap(HierarchyWidget, "render", function (render) {
     render.call(this);
 
     this.$(".g-folder-header-buttons").prepend(openButton);
     const buttons = this.$el.find(".open-in-volview");
+    const button = buttons[0];
 
-    buttons[0].onclick = () => {
+    button.onclick = () => {
         const resources = JSON.parse(this._getCheckedResourceParam());
         openResources(this.parentModel, resources);
     };
+
+    const updateChecked = () => {
+        const resources = this._getCheckedResourceParam();
+        button.innerHTML = resources.length >= 3 ? openChecked : openFolder;
+    };
+    updateChecked();
+
+    this.listenTo(this.itemListView, "g:checkboxesChanged", updateChecked);
+    this.listenTo(this.folderListView, "g:checkboxesChanged", updateChecked);
 });

--- a/girder_volview/web_client/views/HierarchyWidget.js
+++ b/girder_volview/web_client/views/HierarchyWidget.js
@@ -1,34 +1,16 @@
 import HierarchyWidget from "@girder/core/views/widgets/HierarchyWidget";
 import { wrap } from "@girder/core/utilities/PluginUtils";
-import { openButton, openFiles } from "./open";
+import { openButton, openResources } from "./open";
 import { restRequest } from "@girder/core/rest";
 
 wrap(HierarchyWidget, "render", function (render) {
     render.call(this);
 
-    this.$(".g-folder-header-buttons .g-folder-info-button").before(openButton);
+    this.$(".g-folder-header-buttons").prepend(openButton);
     const buttons = this.$el.find(".open-in-volview");
 
     buttons[0].onclick = () => {
         const resources = JSON.parse(this._getCheckedResourceParam());
-        const items = resources.item.map((cid) =>
-            this.itemListView.collection.get(cid)
-        );
-        Promise.all(
-            items.map((item) => {
-                return new Promise((resolve) => {
-                    restRequest({
-                        type: "GET",
-                        url: `item/${item.id}/files?limit=0`,
-                        error: null,
-                    }).done((files) => {
-                        resolve(files);
-                    });
-                });
-            })
-        ).then((files) => {
-            const allFiles = files.flat();
-            openFiles(this.parentModel, allFiles);
-        });
+        openResources(this.parentModel, resources);
     };
 });

--- a/girder_volview/web_client/views/HierarchyWidget.js
+++ b/girder_volview/web_client/views/HierarchyWidget.js
@@ -8,6 +8,10 @@ const openChecked = '<i class="icon-link-ext"></i>Open Checked in VolView</a>';
 wrap(HierarchyWidget, "render", function (render) {
     render.call(this);
 
+    // Can't open/save at root of Collections, for now.
+    if (this.parentModel.attributes._modelType !== "folder") {
+        return;
+    }
     this.$(".g-folder-header-buttons").prepend(openButton);
     const buttons = this.$el.find(".open-in-volview");
     const button = buttons[0];

--- a/girder_volview/web_client/views/HierarchyWidget.js
+++ b/girder_volview/web_client/views/HierarchyWidget.js
@@ -8,7 +8,8 @@ const openFolder = '<i class="icon-link-ext"></i>Open Folder in VolView</a>';
 const openChecked = '<i class="icon-link-ext"></i>Open Checked in VolView</a>';
 
 function loadResources(parentModel, resources) {
-    // update lastOpened so manifest endpoint opens it
+    // update lastOpened so manifest endpoint opens checked resource
+    // rather than newest session.volview.zip with matching resource set.
     const itemId =
         resources.item && resources.item.length >= 1 && resources.item[0];
     const folderId =

--- a/girder_volview/web_client/views/itemPage.js
+++ b/girder_volview/web_client/views/itemPage.js
@@ -1,18 +1,14 @@
 import { wrap } from "@girder/core/utilities/PluginUtils";
 import ItemView from "@girder/core/views/body/ItemView";
-import { open } from "./open";
+import { openItem, openButton } from "./open";
 
 const brandName = "VolView";
 
 wrap(ItemView, "render", function (render) {
     this.once("g:rendered", function () {
-        this.$el.find(".g-item-header .btn-group").before(
-            `<a class="btn btn-sm btn-primary open-in-volview" style="margin-left: 10px" role="button">
-                <i class="icon-link-ext"></i>Open in ${brandName}
-            </a>`
-        );
+        this.$el.find(".g-item-header .btn-group").before(openButton);
         const buttons = this.$el.find(".open-in-volview");
-        buttons[0].onclick = () => open(this.model);
+        buttons[0].onclick = () => openItem(this.model);
     });
     render.call(this);
 });

--- a/girder_volview/web_client/views/open.js
+++ b/girder_volview/web_client/views/open.js
@@ -1,4 +1,4 @@
-import { restRequest, getApiRoot } from "@girder/core/rest";
+import { getApiRoot } from "@girder/core/rest";
 
 export const openButton = `<a class="btn btn-sm btn-primary open-in-volview" style="margin-left: 10px" role="button">
                                 <i class="icon-link-ext"></i>Open in VolView</a>`;
@@ -6,42 +6,19 @@ export const openButton = `<a class="btn btn-sm btn-primary open-in-volview" sty
 const origin = globalThis.location.origin;
 const volViewPath = `${origin}/static/built/plugins/volview/index.html`;
 
-function isSessionFile(fileName) {
-    return fileName.endsWith("volview.zip");
-}
-
-function makeDownloadParams(model, itemRoute, files) {
-    if (files.length === 0) return "";
-
-    const hasSessionFiles = files.some(({ name }) => isSessionFile(name));
-    const { url: downloadUrl, name } = hasSessionFiles
-        ? { url: `${itemRoute}/volview`, name: `${model.name()}.volview.zip` }
-        : {
-              url: `${itemRoute}/volview/manifest`,
-              name: `${model.name()}-files.json`,
-          };
-
-    return `&names=[${name}]&urls=[${downloadUrl}]`;
-}
-
 export function openItem(item) {
-    restRequest({
-        type: "GET",
-        url: `item/${item.id}/files?limit=0`,
-        error: null,
-    }).done((files) => {
-        const itemRoute = `/${getApiRoot()}/item/${item.id}`;
-        const saveParam = `&save=${itemRoute}/volview`;
-        const downloadParams = makeDownloadParams(item, itemRoute, files);
-        const newTabUrl = `${volViewPath}?${saveParam}${downloadParams}`;
-        window.open(newTabUrl, "_blank").focus();
-    });
+    const itemRoute = `/${getApiRoot()}/item/${item.id}`;
+    const saveParam = `&save=${itemRoute}/volview`;
+    const manifestUrl = `${itemRoute}/volview`;
+    const downloadParams = `&names=[manifest.json]&urls=${manifestUrl}`;
+    const newTabUrl = `${volViewPath}?${saveParam}${downloadParams}`;
+    window.open(newTabUrl, "_blank").focus();
 }
 
-function resourcesToDownloadParams(folder, resources) {
+function resourcesToDownloadParams(folderId, resources) {
     const items = (resources.item || []).join(",");
     const folders = (resources.folder || []).join(",");
-    const manifestUrl = `/${getApiRoot()}/folder/${folder}/volview_manifest?folders=${folders}&items=${items}`;
+    const manifestUrl = `/${getApiRoot()}/folder/${folderId}/volview?folders=${folders}&items=${items}`;
     return `&names=[manifest.json]&urls=${encodeURIComponent(manifestUrl)}`;
 }
 

--- a/girder_volview/web_client/views/open.js
+++ b/girder_volview/web_client/views/open.js
@@ -21,9 +21,7 @@ function makeDownloadParams(model, itemRoute, files) {
               name: `${model.name()}-files.json`,
           };
 
-    const configUrl = `${itemRoute}/volview/config/.volview_config.yaml`;
-
-    return `&names=[${name},config.json]&urls=[${downloadUrl},${configUrl}]`;
+    return `&names=[${name}]&urls=[${downloadUrl}]`;
 }
 
 export function openItem(item) {

--- a/girder_volview/web_client/views/open.js
+++ b/girder_volview/web_client/views/open.js
@@ -1,5 +1,8 @@
 import { restRequest, getApiRoot } from "@girder/core/rest";
 
+export const openButton = `<a class="btn btn-sm btn-primary open-in-volview" style="margin-left: 10px" role="button">
+                                <i class="icon-link-ext"></i>Open in VolView</a>`;
+
 const origin = globalThis.location.origin;
 const volViewPath = `${origin}/static/built/plugins/volview/index.html`;
 
@@ -7,49 +10,60 @@ function isSessionFile(fileName) {
     return fileName.endsWith("volview.zip");
 }
 
-function makeDownloadParams(model, itemRoute, files, config) {
+function makeDownloadParams(model, itemRoute, files) {
     if (files.length === 0) return "";
 
     const hasSessionFiles = files.some(({ name }) => isSessionFile(name));
-    const { url:downloadUrl, name } = hasSessionFiles
-        ? { url:`${itemRoute}/volview`, name: `${model.name()}.volview.zip` }
-        : { url:`${itemRoute}/volview/manifest`, name: `${model.name()}-files.json` }
+    const { url: downloadUrl, name } = hasSessionFiles
+        ? { url: `${itemRoute}/volview`, name: `${model.name()}.volview.zip` }
+        : {
+              url: `${itemRoute}/volview/manifest`,
+              name: `${model.name()}-files.json`,
+          };
 
     const configUrl = `${itemRoute}/volview/config/.volview_config.yaml`;
 
     return `&names=[${name},config.json]&urls=[${downloadUrl},${configUrl}]`;
 }
 
-export function open(model) {
+export function openItem(item) {
     restRequest({
         type: "GET",
-        url: `item/${model.id}/files?limit=0`,
+        url: `item/${item.id}/files?limit=0`,
         error: null,
-    })
-        .done((files) => {
-            restRequest({
-                url: `folder/${model.get(
-                    "folderId"
-                )}/yaml_config/.volview_config.yaml`,
-            }).done((config) => {
-                const itemRoute = `/${getApiRoot()}/item/${model.id}`;
-                const saveParam = `&save=${itemRoute}/volview`;
-                const downloadParams = makeDownloadParams(
-                    model,
-                    itemRoute,
-                    files,
-                    config
-                );
-                const newTabUrl = `${volViewPath}?${saveParam}${downloadParams}`;
-                window.open(newTabUrl, "_blank").focus();
-            });
+    }).done((files) => {
+        const itemRoute = `/${getApiRoot()}/item/${item.id}`;
+        const saveParam = `&save=${itemRoute}/volview`;
+        const downloadParams = makeDownloadParams(item, itemRoute, files);
+        const newTabUrl = `${volViewPath}?${saveParam}${downloadParams}`;
+        window.open(newTabUrl, "_blank").focus();
+    });
+}
+
+function filesToDownloadParams(files) {
+    // Find session file in same folder
+    // Filter out session files
+    const fileUrls = files
+        .map((file) => {
+            return [
+                "",
+                getApiRoot(),
+                "file",
+                String(file._id),
+                "proxiable",
+                file.name,
+            ].join("/");
         })
-        .fail((resp) => {
-            events.trigger("g:alert", {
-                icon: "cancel",
-                text: "Could not check for config file for VolView",
-                type: "danger",
-                timeout: 4000,
-            });
-        });
+        .join(",");
+    const fileNames = files.map((file) => file.name).join(",");
+
+    return `&names=[${fileNames}]&urls=[${fileUrls}]`;
+}
+
+export function openFiles(folder, files) {
+    const folderRoute = `/${getApiRoot()}/folder/${folder.id}`;
+    const saveParam = `&save=${folderRoute}/volview`;
+    const downloadParams = filesToDownloadParams(files);
+    const newTabUrl = `${volViewPath}?${saveParam}${downloadParams}`;
+    window.open(newTabUrl, "_blank").focus();
 }

--- a/girder_volview/web_client/views/open.js
+++ b/girder_volview/web_client/views/open.js
@@ -24,7 +24,15 @@ function resourcesToDownloadParams(folderId, resources) {
 
 export function openResources(folder, resources) {
     const folderRoute = `/${getApiRoot()}/folder/${folder.id}`;
-    const saveParam = `&save=${folderRoute}/volview`;
+    const metaData = {
+        linkedResources: {
+            items: resources.item,
+            folders: resources.folder,
+        },
+    };
+    const saveParam = `&save=${folderRoute}/volview?metadata=${encodeURIComponent(
+        JSON.stringify(metaData)
+    )}`;
     const downloadParams = resourcesToDownloadParams(folder.id, resources);
     const newTabUrl = `${volViewPath}?${saveParam}${downloadParams}`;
     window.open(newTabUrl, "_blank").focus();

--- a/girder_volview/web_client/views/open.js
+++ b/girder_volview/web_client/views/open.js
@@ -40,30 +40,17 @@ export function openItem(item) {
     });
 }
 
-function filesToDownloadParams(files) {
-    // Find session file in same folder
-    // Filter out session files
-    const fileUrls = files
-        .map((file) => {
-            return [
-                "",
-                getApiRoot(),
-                "file",
-                String(file._id),
-                "proxiable",
-                file.name,
-            ].join("/");
-        })
-        .join(",");
-    const fileNames = files.map((file) => file.name).join(",");
-
-    return `&names=[${fileNames}]&urls=[${fileUrls}]`;
+function resourcesToDownloadParams(folder, resources) {
+    const items = (resources.item || []).join(",");
+    const folders = (resources.folder || []).join(",");
+    const manifestUrl = `/${getApiRoot()}/folder/${folder}/volview_manifest?folders=${folders}&items=${items}`;
+    return `&names=[manifest.json]&urls=${encodeURIComponent(manifestUrl)}`;
 }
 
-export function openFiles(folder, files) {
+export function openResources(folder, resources) {
     const folderRoute = `/${getApiRoot()}/folder/${folder.id}`;
     const saveParam = `&save=${folderRoute}/volview`;
-    const downloadParams = filesToDownloadParams(files);
+    const downloadParams = resourcesToDownloadParams(folder.id, resources);
     const newTabUrl = `${volViewPath}?${saveParam}${downloadParams}`;
     window.open(newTabUrl, "_blank").focus();
 }

--- a/volview-girder-client/buildvolview.sh
+++ b/volview-girder-client/buildvolview.sh
@@ -1,4 +1,4 @@
-#!/bin/sh bash
+#!/bin/bash
 rm -rf VolView
 mkdir VolView
 cd VolView

--- a/volview-girder-client/buildvolview.sh
+++ b/volview-girder-client/buildvolview.sh
@@ -6,7 +6,7 @@ cd VolView
 # fetch just one commit
 git init
 git remote add origin https://github.com/Kitware/VolView.git
-git fetch origin b1951c47250763068793e58e120bc3e6f23daadc --depth 1
+git fetch origin 3cadfb06845178fe854c30cd6ab45ff42c704d14 --depth 1
 git reset --hard FETCH_HEAD
 
 npm install

--- a/volview-girder-client/package.json
+++ b/volview-girder-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "volview-girder-client",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "Built VolView with public path for DSA",
     "main": "index.js",
     "homepage": "https://github.com/girder/girder_volview",


### PR DESCRIPTION
![image](https://github.com/PaulHax/girder_volview/assets/16823231/628e59cb-527b-48b8-b14c-ef9f6ef00372)


- [x] Picking the latest session.volview.zip file when "Open Folder"
- [x] Port new logic to old "Open in VolView" button when in an Item.
- [x] Update README

### Test cases

- What if a single item with images is checked with matching session.volview.zip file?  Verify VolView loads just images, no anntations.  Make annotation, save, refresh.  Verify annotation is loaded.  
- Folder and volview.zip item checked? Verify VolView loads volview.zip.

Later?
- [x] Deal with multiple checked volview.zip files.
- [ ] Support opening at Collection Root level